### PR TITLE
Dynamic users, switch with gosu in entrypoint

### DIFF
--- a/deeplearning/Dockerfile
+++ b/deeplearning/Dockerfile
@@ -32,7 +32,7 @@ RUN sed -i.bkp -e \
 # gosu is an improved version of su which behaves better inside docker
 # we use it to dynamically switch to the desired user in the entrypoint
 # (see below)
-ENV GOSU_VERSION 1.9
+ENV GOSU_VERSION 1.10
 # Use unsecure HTTP via Port 80 to fetch key due to firewall in CIN.
 RUN set -x \
     && apt-get update && apt-get install -y --no-install-recommends ca-certificates && rm -rf /var/lib/apt/lists/* \

--- a/deeplearning/Dockerfile
+++ b/deeplearning/Dockerfile
@@ -8,11 +8,7 @@ USER root
 ENV TZ=Europe/Berlin
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
-# Set USER & ID
 ENV SHELL /bin/bash
-ENV NB_USER wbrendel
-ENV NB_UID 5321
-ENV HOME /gpfs01/bethge/home/$NB_USER
 
 # Install SSH, sudo and gfortran, etc.
 RUN apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends \
@@ -27,19 +23,35 @@ RUN apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install -yq --n
 		xterm \
 		&& rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-# Create jovyan user with UID=1000 and in the 'users' group
-RUN groupadd -g 1019 bethgelab && \
-	groupadd -g 1011 cin && \
-	useradd -m -s /bin/bash -N -u $NB_UID $NB_USER && \
-	usermod -g bethgelab $NB_USER && \
-	usermod -a -G cin $NB_USER && \
-	usermod -a -G sudo $NB_USER
-
 # Enable passwordless sudo for users under the "sudo" group
 RUN sed -i.bkp -e \
       's/%sudo\s\+ALL=(ALL\(:ALL\)\?)\s\+ALL/%sudo ALL=NOPASSWD:ALL/g' \
 	  /etc/sudoers
 
+# Setup gosu (https://github.com/tianon/gosu)
+# gosu is an improved version of su which behaves better inside docker
+# we use it to dynamically switch to the desired user in the entrypoint
+# (see below)
+ENV GOSU_VERSION 1.9
+# Use unsecure HTTP via Port 80 to fetch key due to firewall in CIN.
+RUN set -x \
+    && apt-get update && apt-get install -y --no-install-recommends ca-certificates && rm -rf /var/lib/apt/lists/* \
+    && dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')" \
+    && wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch" \
+    && wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc" \
+    && export GNUPGHOME="$(mktemp -d)" \
+    && gpg --keyserver "hkp://ha.pool.sks-keyservers.net:80" --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+    && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
+    && rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc \
+    && chmod +x /usr/local/bin/gosu \
+    && gosu nobody true \
+    && apt-get purge -y --auto-remove ca-certificates
+
+
+COPY entrypoint.sh /usr/local/bin/
+RUN chmod a+x /usr/local/bin/entrypoint.sh
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 
 # Use https:// instead of git:// to access github (e.g. for jupyter install)
 RUN apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends \
@@ -87,13 +99,16 @@ RUN pip3 --no-cache-dir install \
 		&& \
     python3 -m ipykernel.kernelspec
 
+
+
+
 # Jupyter has issues with being run directly:
 #   https://github.com/ipython/ipython/issues/7062
 # We just add a little wrapper script.
-COPY run_jupyter.sh /
-RUN chmod +x /run_jupyter.sh && \
+COPY run_jupyter.sh /usr/local/bin
+RUN chmod +x /usr/local/bin/run_jupyter.sh && \
     chmod -R a+rwx /usr/.jupyter
 
 USER $NB_USER
 
-CMD ["/run_jupyter.sh"]
+CMD ["/usr/local/bin/run_jupyter.sh"]

--- a/deeplearning/Dockerfile
+++ b/deeplearning/Dockerfile
@@ -12,6 +12,7 @@ ENV SHELL /bin/bash
 
 # Install SSH, sudo and gfortran, etc.
 RUN apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends \
+        ca-certificates \
 		gfortran \
 		openssh-server \
 		pwgen \
@@ -35,17 +36,10 @@ RUN sed -i.bkp -e \
 ENV GOSU_VERSION 1.10
 # Use unsecure HTTP via Port 80 to fetch key due to firewall in CIN.
 RUN set -x \
-    && apt-get update && apt-get install -y --no-install-recommends ca-certificates && rm -rf /var/lib/apt/lists/* \
     && dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')" \
     && wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch" \
-    && wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc" \
-    && export GNUPGHOME="$(mktemp -d)" \
-    && gpg --keyserver "hkp://ha.pool.sks-keyservers.net:80" --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
-    && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
-    && rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc \
     && chmod +x /usr/local/bin/gosu \
-    && gosu nobody true \
-    && apt-get purge -y --auto-remove ca-certificates
+    && gosu nobody true
 
 
 COPY entrypoint.sh /usr/local/bin/

--- a/deeplearning/Dockerfile
+++ b/deeplearning/Dockerfile
@@ -99,9 +99,6 @@ RUN pip3 --no-cache-dir install \
 		&& \
     python3 -m ipykernel.kernelspec
 
-
-
-
 # Jupyter has issues with being run directly:
 #   https://github.com/ipython/ipython/issues/7062
 # We just add a little wrapper script.

--- a/deeplearning/entrypoint.sh
+++ b/deeplearning/entrypoint.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+# Create user account
+if [ -n "$USER" ]; then
+   if [ -z "$USER_HOME" ]; then
+      export USER_HOME=/home/$USER
+   fi
+
+   if [ -z "$USER_ID" ]; then
+      export USER_ID=99
+   fi
+
+
+   if [ -n "$USER_ENCRYPTED_PASSWORD" ]; then
+      useradd -M -d $USER_HOME -p $USER_ENCRYPTED_PASSWORD -u $USER_ID $USER > /dev/null
+   else
+      useradd -M -d $USER_HOME -u $USER_ID $USER > /dev/null
+   fi
+   
+   # expects a comma-separated string of the form GROUP1:GROUP1ID,GROUP2,GROUP3:GROUP3ID,... 
+   # (the GROUPID is optional, but needs to be separated from the group name by a ':')
+   for i in $(echo $USER_GROUPS | sed "s/,/ /g")
+   do
+      if [[ $i == *":"* ]]
+      then
+	 addgroup ${i%:*} # > /dev/null
+         groupmod -g ${i#*:} ${i%:*} #> /dev/null
+         adduser $USER ${i%:*} #> /dev/null
+      else
+         addgroup $i > /dev/null
+         adduser $USER $i > /dev/null
+      fi
+   done
+
+   # set correct primary group
+   if [ -n "$USER_GROUPS" ]; then
+      group="$( cut -d ',' -f 1 <<< "$USER_GROUPS" )"
+      if [[ $group == *":"* ]]
+      then
+         usermod -g ${group%:*} $USER & 
+      else
+         usermod -g $group $USER &
+      fi
+   fi
+
+  if [ -n $CWD ]; then cd $CWD; fi
+  echo "Running as user $USER"
+  exec gosu $USER "$@"
+else
+  if [ -n $CWD ]; then cd $CWD; fi
+  echo "Running as default container user"
+  exec "$@"
+fi


### PR DESCRIPTION
I added the code to create our LDAP user on the fly, as we do it in the old containers. The user has to be provided as enviroment variable `$USER` (as before). There are two main differences:

* the code now runs in an entrypoint, therefore you can still overwrite the `CMD` which is executed in the end without loosing the new user
* I use [gosu](https://github.com/tianon/gosu) to switch the user to `$USER` and then executing `CMD`. This `su` variant behaves better with respect to docker and makes it much easier to execute complated `CMD`s later.
* you can provide `$CWD` to indicate in which directory `CMD` should run.

Examples:

To start the container, link GPFS and start jupyter as own user (as before)

    agmb-docker run -it bethgelab/deeplearning

To start the container, link GPFS and start a shell as own user:

    agmb-docker run -it bethgelab/deeplearning bash

To start the container, link GPFS and execute something else as own user:

    agmb-docker run -it bethgelab/deeplearning python /location/of/myscript.py

To start the container, link GPFS and execute python as own user in current directory (and exit the container as soon as the script has finished):

    agmb-docker run -it -eCWD=`pwd` bethgelab/deeplearning python myscript.py

closes #1 