### PR TITLE
Add jupyterlab to container

### DIFF
--- a/deeplearning/Dockerfile
+++ b/deeplearning/Dockerfile
@@ -83,6 +83,7 @@ RUN pip3 --no-cache-dir install \
     tqdm \
     ipykernel \
     jupyter \
+    jupyterlab \
     matplotlib \
     numpy \
     scipy \
@@ -106,8 +107,10 @@ RUN pip install jupyter_contrib_nbextensions \
 #   https://github.com/ipython/ipython/issues/7062
 # We just add a little wrapper script.
 COPY run_jupyter.sh /usr/local/bin
+COPY run_jupyterlab.sh /usr/local/bin
 RUN chmod +x /usr/local/bin/run_jupyter.sh \
- && chmod -R a+rwx /usr/.jupyter
+ && chmod -R a+rwx /usr/.jupyter \
+ && chmod +x /usr/local/bin/run_jupyterlab.sh
 
 USER $NB_USER
 

--- a/deeplearning/run_jupyterlab.sh
+++ b/deeplearning/run_jupyterlab.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+jupyter lab --ip=0.0.0.0 --no-browser --notebook-dir=$USER_HOME


### PR DESCRIPTION
This installs jupyterlab and adds a new script
/usr/local/bin/run_jupyterlab.sh that can be used
instead of the usual /usr/local/bin/run_jupyter.sh
to start jupyterlab instead of the notebook.