### PR TITLE
set container name postfix via environment variable

### DIFF
--- a/agmb-docker
+++ b/agmb-docker
@@ -139,6 +139,8 @@ gpu_name = GPU.translate(None, ',') if GPU != "cpu" else 'CPU'
 container_name = os.environ['USER'] + gpu_name
 if args.name != "":
     container_name = container_name + "-" + args.name
+if os.environ.get('CONTAINER_POSTFIX'):
+    container_name = container_name + "-" + os.environ['CONTAINER_POSTFIX']
 
 # encrypt passwords
 args.pw = crypt.crypt(args.pw, 'aa')


### PR DESCRIPTION
This extends `agmb-docker` to check if the environment variable `CONTAINER_POSTFIX` is set and if so, it appends the value to the container name. Since more and more people are using my `gpumonitor`, I would like to make it available to everybody and this feature means that the scheduling function of the gpumonitor works natively with agmb-docker without scripts inbetween.