### PR TITLE
disable GPUs for CPU containers

### DIFF
--- a/agmb-docker
+++ b/agmb-docker
@@ -17,6 +17,7 @@ except KeyError:
     GPU = ''
 if GPU == '':
     GPU = 'cpu'
+    os.environ['NV_GPU'] = ','  # empty NV_GPU leads to all GPUs being mounted into the container
 
 # find IP address of network interface
 def get_ip_address(ifname):


### PR DESCRIPTION
It turns out that setting `NV_GPU` to an empty string does lead to `nvidia-docker` mounting all GPUs into the container, instead of None. The only way to achieve a pure cpu container that I found is setting `NV_GPU=','`. This fixed `agmb-docker` accordingly.